### PR TITLE
add support for datomic-free and datomic-mysql

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,7 @@
 
 This is a plugin for Fulcro RAD that adds support for using Datomic databases as the back-end technology.
 
-NOTE: The current version only supports on-prem with a PostgreSQL store. There is
-nothing in the design that requires this, it has just not yet been generalized.
+NOTE: The current version supports on-prem Datomic Pro (PostgreSQL or MySQL backends), Datomic Free, or Mem stores.
 
 == Conventions
 
@@ -185,34 +184,25 @@ can use `(datomic/reset-test-schema k)` to forget the current memoized version.
 
 We use git (with git flow) for source control. Please branch and make PRs against the `develop` branch.
 
-The source of this repository includes an example application that can be used when developing features.
-It is enabled on the source path using the Clj deps `dev` alias. This alias also overrides the `fulcro-rad` dependency
-to a local disk directory (you need to check out and edit deps). This allows you to work on the RAD source code
-at the same time as the Datomic and example code.
+There is an example application https://github.com/fulcrologic/fulcro-rad-demo[fulcrologic/fulcro-rad-demo] that can be
+used when developing features.
 
-In general you will clone both this repository and the `fulcro-rad` one as well.
-
-You will need Datomic using a PostgreSQL backend to run the example. Follow the instructions for setting that up, and then
+You will need Datomic Pro with a PostgreSQL or MySQL backend or Datomic Free to run the example. Follow the instructions for setting that up, and then
 edit the `defaults.edn` file in `src/example/config` and update the database parameters to match your system.
 
-Once you have Datomic running you'll need to start a cljs build.
+```
+ :com.fulcrologic.rad.database-adapters.datomic/databases
+    {:main {:datomic/schema           :production
+            :datomic/driver           :postgresql ;; OR :mysql :free :mem
+            :datomic/database         "example"
+            :datomic/prevent-changes? true
+            :postgresql/host          "localhost"
+            :postgresql/port          5432
+            :postgresql/user          "datomic"
+            :postgresql/password      "datomic"
+            :postgresql/database      "datomic"
+            :free/host                "localhost"
+            :free/port                4334}}
+```
 
-[source,bash]
-------
-$ shadow-cljs server
-------
-
-Then go to dashboard URL and start the `example` CLJS build at http://localhost:9630. Then, you'll start a REPL
-for working on the CLJ stuff:
-
-[source,bash]
-------
-$ clj -A:dev
-user=> (require 'development)
-user=> (in-ns 'development)
-development=> (go)
-------
-
-will start a server and should make the demo accessible at http://localhost:3000/index.html. The `(restart)` function
-will stop the server, refresh server source, and restart it.
 

--- a/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
@@ -295,14 +295,32 @@
   (str "datomic:sql://" datomic-db "?jdbc:postgresql://" host (when port (str ":" port)) "/"
     database "?user=" user "&password=" password))
 
-(defn config->url [{:datomic/keys [storage-protocol driver]
-                    :or           {storage-protocol :sql}
+(defn config->mysql-url [{:mysql/keys [user host port password database]
+                          datomic-db       :datomic/database}]
+  (assert user ":mysql/user must be specified")
+  (assert host ":mysql/host must be specified")
+  (assert port ":mysql/port must be specified")
+  (assert password ":mysql/password must be specified")
+  (assert database ":mysql/database must be specified")
+  (assert datomic-db ":datomic/database must be specified")
+  (str "datomic:sql://" datomic-db "?jdbc:mysql://" host (when port (str ":" port)) "/"
+    database "?user=" user "&password=" password "&useSSL=false"))
+
+(defn config->free-url [{:free/keys [host port]
+                         datomic-db :datomic/database}]
+  (assert host ":free/host must be specified")
+  (assert port ":free/port must be specified")
+  (assert datomic-db ":datomic/database must be specified")
+  (str "datomic:free://" host ":" port "/" datomic-db))
+
+(defn config->url [{:datomic/keys [driver]
                     :as           config}]
-  (case storage-protocol
+  (case driver
     :mem (str "datomic:mem://" (:datomic/database config))
-    :sql (case driver
-           :postgresql (config->postgres-url config)
-           (throw (ex-info "Unsupported Datomic back-end driver." {:driver driver})))))
+    :free (config->free-url config)
+    :postgresql (config->postgres-url config)
+    :mysql (config->mysql-url config)
+    (throw (ex-info "Unsupported Datomic driver." {:driver driver}))))
 
 (defn ensure-transactor-functions!
   "Must be called on any Datomic database that will be used with automatic form save. This


### PR DESCRIPTION
I simplified the driver situation to just use `:datomic/driver` and removed `:datomic/storage-protocol`. It seems that the only thing that would really require the use of that key would be the client protocol.  The value would then be something like either `:on-prem` or `:client`.