### PR TITLE
Add support for ::pc/transform in `id-resolver`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
                        :extra-deps {dev-local-tu             {:mvn/version "0.1.0"}
                                     ; N.B. - follow instuctions for installing dev-local
                                     ; https://docs.datomic.com/cloud/dev-local.html#using
-                                    com.datomic/dev-local    {:mvn/version "0.9.203"}
+                                    com.datomic/dev-local    {:mvn/version "0.9.195"}
                                     com.datomic/client-cloud {:mvn/version "0.8.102"}}}
 
            :provided  {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5697"

--- a/src/main/com/fulcrologic/rad/database_adapters/datomic_cloud.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic_cloud.clj
@@ -282,7 +282,7 @@
 (>defn id-resolver
   "Generates a resolver from `id-attribute` to the `output-attributes`."
   [all-attributes
-   {::attr/keys [qualified-key] :keys [::attr/schema ::wrap-resolve] :as id-attribute}
+   {::attr/keys [qualified-key] :keys [::attr/schema ::wrap-resolve ::pc/transform] :as id-attribute}
    output-attributes]
   [::attr/attributes ::attr/attribute ::attr/attributes => ::pc/resolver]
   (log/info "Building ID resolver for" qualified-key)
@@ -297,22 +297,24 @@
                                (r (assoc env ::pc/sym resolve-sym) input)))]
       (log/debug "Computed output is" outputs)
       (log/debug "Datomic pull query to derive output is" pull-query)
-      {::pc/sym     resolve-sym
-       ::pc/output  outputs
-       ::pc/batch?  true
-       ::pc/resolve (cond-> (fn [{::attr/keys [key->attribute] :as env} input]
-                              (->> (entity-query
-                                     (assoc env
-                                       ::attr/schema schema
-                                       ::attr/attributes output-attributes
-                                       ::id-attribute id-attribute
-                                       ::default-query pull-query)
-                                     input)
-                                (common/datomic-result->pathom-result key->attribute outputs)
-                                (auth/redact env)))
-                      wrap-resolve (wrap-resolve)
-                      :always (with-resolve-sym))
-       ::pc/input   #{qualified-key}})
+      (cond-> {::pc/sym     resolve-sym
+               ::pc/output  outputs
+               ::pc/batch?  true
+               ::pc/resolve (cond-> (fn [{::attr/keys [key->attribute] :as env} input]
+                                      (->> (entity-query
+                                             (assoc env
+                                               ::attr/schema schema
+                                               ::attr/attributes output-attributes
+                                               ::id-attribute id-attribute
+                                               ::default-query pull-query)
+                                             input)
+                                        (common/datomic-result->pathom-result key->attribute outputs)
+                                        (auth/redact env)))
+                              wrap-resolve (wrap-resolve)
+                              :always (with-resolve-sym))
+               ::pc/input   #{qualified-key}
+               }
+        transform transform))
     (do
       (log/error "Unable to generate id-resolver. "
         "Attribute was missing schema, or could not be found in the attribute registry: " qualified-key)

--- a/src/test-cloud/com/fulcrologic/rad/database_adapters/datomic_cloud_spec.clj
+++ b/src/test-cloud/com/fulcrologic/rad/database_adapters/datomic_cloud_spec.clj
@@ -452,3 +452,16 @@
                      ::person/primary-address {::address/id     addr-id
                                                ::address/street "A St"}})))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Attr Options Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(specification "Attribute Options"
+  (let [person-resolver (first (datomic/generate-resolvers person/attributes :production))]
+    (component "defattr applies ::pc/transform to the resolver map"
+      (assertions
+        "person resolver has been transformed by ::pc/transform"
+        (do
+          (log/spy :info person-resolver)
+          (::person/transform-succeeded person-resolver)) => true
+        ))))

--- a/src/test/com/fulcrologic/rad/database_adapters/datomic_spec.clj
+++ b/src/test/com/fulcrologic/rad/database_adapters/datomic_spec.clj
@@ -442,3 +442,16 @@
                      ::person/primary-address {::address/id     addr-id
                                                ::address/street "A St"}})))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Attr Options Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(specification "Attribute Options"
+  (let [person-resolver (first (datomic/generate-resolvers person/attributes :production))]
+    (component "defattr applies ::pc/transform to the resolver map"
+      (assertions
+        "person resolver has been transformed by ::pc/transform"
+        (do
+          (log/spy :info person-resolver)
+          (::person/transform-succeeded person-resolver)) => true
+        ))))

--- a/src/test/com/fulcrologic/rad/test_schema/person.clj
+++ b/src/test/com/fulcrologic/rad/test_schema/person.clj
@@ -3,6 +3,7 @@
     [com.fulcrologic.rad.form :as form]
     [com.fulcrologic.rad.attributes :as attr :refer [defattr]]
     [com.fulcrologic.rad.authorization :as auth]
+    [com.wsscode.pathom.connect :as pc]
     [com.fulcrologic.rad.database-adapters.datomic :as datomic]
     [com.fulcrologic.rad.database-adapters.datomic-options :as do]
     [taoensso.timbre :as log]))
@@ -10,7 +11,11 @@
 (defattr id ::id :long
   {::attr/identity?     true
    do/native-id?        true
-   ::attr/schema        :production})
+   ::attr/schema        :production
+   ::pc/transform (fn [resolver]
+                    (assoc resolver ::transform-succeeded true))
+
+   })
 
 (defattr full-name ::full-name :string
   {::attr/schema     :production


### PR DESCRIPTION
**Motivation:** Opens up new possibilities for custom auth plugins into RAD. 

`defresolver`'s `::pc/transform` has been used to build an auth framework by other [fulcro users](https://github.com/souenzzo/eql-style-guide/issues/4#issuecomment-664509666). However, RAD's attributes bypass `defresolver` and instead builds the resolver map manually. 

This PR adds the ability to specify a `::pc/transform` in an attribute.

If we want to merge this PR I would also like to:

1. Add an `attributes-options/pc-transform` to RAD to clean this up.
2. Add similar functionality to RAD's `attribute-resolver`

The `deps.edn` change just bumps dev-local to a more recent version (needed for testing, but I can move to another PR if preferred). 