### PR TITLE
Fix test to use realistic delta for person/role

### DIFF
--- a/src/test/com/fulcrologic/rad/database_adapters/datomic_spec.clj
+++ b/src/test/com/fulcrologic/rad/database_adapters/datomic_spec.clj
@@ -338,7 +338,7 @@
         delta   {[::person/id tempid1]           {::person/id              tempid1
                                                   ::person/full-name       {:after "Bob"}
                                                   ::person/primary-address {:after [::address/id (ids/new-uuid 1)]}
-                                                  ::person/role            :com.fulcrologic.rad.test-schema.person.role/admin}
+                                                  ::person/role            {:after :com.fulcrologic.rad.test-schema.person.role/admin}}
                  [::address/id (ids/new-uuid 1)] {::address/street {:before "A St" :after "A1 St"}}}]
     (let [{:keys [tempids]} (datomic/save-form! *env* {::form/delta delta})
           real-id (get tempids tempid1)


### PR DESCRIPTION
I have tested in the demo that also :enum deltas are sent in the {:before, :after}
format. The test still passes. We can also see the same form alsewhere in this file.