### PR TITLE
Add datomic-cloud/generate-resolvers-pathom3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,12 +4,14 @@
            com.taoensso/timbre        {:mvn/version "4.10.0"}
            com.taoensso/encore        {:mvn/version "2.120.0"}
            com.fulcrologic/guardrails {:mvn/version "1.1.4"}
-           com.fulcrologic/fulcro-rad {:mvn/version "1.0.0-RC1"}
+           com.fulcrologic/fulcro-rad {:mvn/version "1.1.11"}
            vvvvalvalval/datomock      {:mvn/version "0.2.2"}
            org.clojure/clojure        {:mvn/version "1.10.1"}}
 
  :aliases {:test      {:extra-paths ["src/test"]
-                       :extra-deps  {fulcrologic/fulcro-spec {:mvn/version "3.1.11"}}}
+                       :extra-deps  {fulcrologic/fulcro-spec {:mvn/version "3.1.11"}
+                                     com.wsscode/pathom {:mvn/version "2.4.0"}
+                                     com.wsscode/pathom3 {:mvn/version "2022.04.20-alpha"}}}
 
            :clj-tests {:extra-paths ["src/test"]
                        :main-opts   ["-m" "kaocha.runner"]

--- a/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
@@ -339,12 +339,13 @@
     (common/entity-query* d/pull d/pull-many datoms-for-id-peer-api common-env input)))
 
 (defn id-resolver
-  "Generates a resolver from `id-attribute` to the `output-attributes`."
+  "Generates a Pathom2 resolver from `id-attribute` to the `output-attributes`."
   [all-attributes
    {::attr/keys [qualified-key] :keys [::attr/schema ::wrap-resolve :com.wsscode.pathom.connect/transform] :as id-attribute}
    output-attributes]
   (let [common-id-attribute (assoc id-attribute ::common/wrap-resolve wrap-resolve)]
-    (common/id-resolver-pathom2*
+    (common/id-resolver-pathom*
+      common/make-pathom2-resolver
       d/pull d/pull-many datoms-for-id-peer-api
       all-attributes
       common-id-attribute
@@ -352,9 +353,19 @@
 
 (defn generate-resolvers
   "Generate all of the resolvers that make sense for the given database config. This should be passed
-  to your Pathom parser to register resolvers for each of your schemas."
+   to your Pathom2 parser to register resolvers for each of your schemas."
   [attributes schema]
   (common/generate-resolvers*
+    common/make-pathom2-resolver
+    d/pull d/pull-many datoms-for-id-peer-api
+    attributes schema))
+
+(defn generate-resolvers-pathom3
+  "Generate all of the resolvers that make sense for the given database config. This should be passed
+   to your Pathom3 parser to register resolvers for each of your schemas."
+  [attributes schema]
+  (common/generate-resolvers*
+    common/make-pathom3-resolver
     d/pull d/pull-many datoms-for-id-peer-api
     attributes schema))
 

--- a/src/main/com/fulcrologic/rad/database_adapters/datomic_cloud.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic_cloud.clj
@@ -233,12 +233,13 @@
     (common/entity-query* d/pull pull-many datoms-for-id-client-api common-env input)))
 
 (defn id-resolver
-  "Generates a resolver from `id-attribute` to the `output-attributes`."
+  "Generates a Pathom2 resolver from `id-attribute` to the `output-attributes`."
   [all-attributes
    {::attr/keys [qualified-key] :keys [::attr/schema ::wrap-resolve :com.wsscode.pathom.connect/transform] :as id-attribute}
    output-attributes]
   (let [common-id-attribute (assoc id-attribute ::common/wrap-resolve wrap-resolve)]
-    (common/id-resolver-pathom2*
+    (common/id-resolver-pathom*
+      common/make-pathom2-resolver
       d/pull pull-many datoms-for-id-client-api
       all-attributes
       common-id-attribute
@@ -246,9 +247,19 @@
 
 (defn generate-resolvers
   "Generate all of the resolvers that make sense for the given database config. This should be passed
-  to your Pathom parser to register resolvers for each of your schemas."
+  to your Pathom2 parser to register resolvers for each of your schemas."
   [attributes schema]
   (common/generate-resolvers*
+    common/make-pathom2-resolver
+    d/pull pull-many datoms-for-id-client-api
+    attributes schema))
+
+(defn generate-resolvers-pathom3
+  "Generate all of the resolvers that make sense for the given database config. This should be passed
+  to your Pathom3 parser to register resolvers for each of your schemas."
+  [attributes schema]
+  (common/generate-resolvers*
+    common/make-pathom3-resolver
     d/pull pull-many datoms-for-id-client-api
     attributes schema))
 


### PR DESCRIPTION
Tony, 

This is our best effort to add `datomic-cloud/generate-resolvers-pathom3`.

The challenge is that pathom3 resolvers bottom out as `com.wsscode.pathom3.connect.operation/Resolver` defrecords. So we have to invoke `com.wsscode.pathom3.connect.operation/resolver`.

We did this using `requiring-resolve` to not add the dependency.
