### PR TITLE
adds support for MS SQL Server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ image:https://circleci.com/gh/fulcrologic/fulcro-rad-datomic/tree/master.svg?sty
 
 This is a plugin for Fulcro RAD that adds support for using Datomic databases as the back-end technology.
 
-NOTE: The current version supports on-prem Datomic Pro (PostgreSQL or MySQL backends), Datomic Free, or Mem stores, as well as Datomic Cloud. Make sure
+NOTE: The current version supports on-prem Datomic Pro (PostgreSQL, MySQL, or Microsoft SQL Server backends), Datomic Free, or Mem stores, as well as Datomic Cloud. Make sure
 you do not accidentally get Datomic Free and Datomic Pro BOTH on the CLASSPATH. If you're using deps you should make
 sure you use something like:
 
@@ -226,7 +226,7 @@ edit the `defaults.edn` file in `src/example/config` and update the database par
 ```
  :com.fulcrologic.rad.database-adapters.datomic/databases
     {:main {:datomic/schema           :production
-            :datomic/driver           :postgresql ;; OR :mysql :free :mem
+            :datomic/driver           :postgresql ;; OR :mysql :sqlserver :free :mem
             :datomic/database         "example"
             :datomic/prevent-changes? true
             :postgresql/host          "localhost"

--- a/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic.clj
@@ -181,6 +181,22 @@
   (str "datomic:sql://" datomic-db "?jdbc:mysql://" host (when port (str ":" port)) "/"
     database "?user=" user "&password=" password "&useSSL=false"))
 
+(defn config->sqlserver-url [{:sqlserver/keys [host port user password
+                                               database properties]
+                             datomic-db       :datomic/database
+                             :or              {datomic-db "demo"}}]
+  (let [all-properties (cond-> {}
+                         user (assoc "Username" user)
+                         password (assoc "Password" password)
+                         database (assoc "DatabaseName" database)
+                         properties (merge properties))
+        properties-str (reduce-kv (fn [p k v] (str p ";" k "=" v))
+                                  ""
+                                  all-properties)]
+    (str "datomic:sql://" datomic-db "?jdbc:sqlserver://"
+         (str host (when port (str ":" port)))
+         properties-str)))
+
 (defn config->free-url [{:free/keys [host port]
                          datomic-db :datomic/database}]
   (assert host ":free/host must be specified")
@@ -203,6 +219,7 @@
     :dev (config->dev-url config)
     :postgresql (config->postgres-url config)
     :mysql (config->mysql-url config)
+    :sqlserver (config->sqlserver-url config)
     (throw (ex-info "Unsupported Datomic driver." {:driver driver}))))
 
 (defn ensure-transactor-functions!


### PR DESCRIPTION
This just adds support for Microsoft SQL Server in the Datomic URIs. The JDBC connection url for SQL Server is described here: https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16.

There doesn't seem to be a `develop` branch to merge to as requested by the readme, so I'm targeting `main`.