### PR TITLE
Change the `resolve-sym` of the generated resolver to have datomic in it

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/datomic_common.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic_common.clj
@@ -516,7 +516,7 @@
     (let [wrap-resolve (get id-attribute do/wrap-resolve (get id-attribute ::wrap-resolve))
           resolve-sym  (symbol
                          (str (namespace qualified-key))
-                         (str (name qualified-key) "-resolver"))
+                         (str (name qualified-key) "-resolver-datomic"))
           resolver-fn  (cond-> (fn [{::attr/keys [key->attribute] :as env} input]
                                  (->> (entity-query*
                                         pull-fn pull-many-fn datoms-for-id-fn


### PR DESCRIPTION
This partitions the resolvers to its own namespace, which avoids a clash with https://github.com/fulcrologic/fulcro-rad/commit/bc000ac4b31261890ac702f73a620b57be0faeda