### PR TITLE
Fix: Make it possible to pull :db/id for non-native-id entities

### DIFF
--- a/src/main/com/fulcrologic/rad/database_adapters/datomic_common.clj
+++ b/src/main/com/fulcrologic/rad/database_adapters/datomic_common.clj
@@ -98,6 +98,7 @@
   [k->a ast-nodes result]
   (let [id?                (fn [{:keys [dispatch-key]}] (some-> dispatch-key k->a ::attr/identity?))
         id-key             (:key (first (filter id? ast-nodes)))
+        native-id?         (some-> id-key k->a do/native-id?)
         join-key->children (into {}
                              (comp
                                (filter #(= :join (:type %)))
@@ -108,7 +109,7 @@
     (reduce-kv
       (fn [m k v]
         (cond
-          (= :db/id k) (assoc m id-key v)
+          (and native-id? (= :db/id k)) (assoc m id-key v)
           (and (join-key? k) (vector? v)) (assoc m k (mapv #(fix-id-keys k->a (join-key->children k) %) v))
           (and (join-key? k) (map? v)) (assoc m k (fix-id-keys k->a (join-key->children k) v))
           :otherwise (assoc m k v)))

--- a/src/test/com/fulcrologic/rad/database_adapters/datomic_cloud_spec.clj
+++ b/src/test/com/fulcrologic/rad/database_adapters/datomic_cloud_spec.clj
@@ -13,7 +13,7 @@
     [com.fulcrologic.rad.test-schema.person :as person]
     [com.fulcrologic.rad.test-schema.thing :as thing]
     [datomic.client.api :as d]
-    [fulcro-spec.core :refer [specification assertions component behavior when-mocking]]
+    [fulcro-spec.core :refer [specification assertions component behavior when-mocking =fn=>]]
     [taoensso.timbre :as log]))
 
 (declare =>)
@@ -440,7 +440,12 @@
           (uuid? real-id) => true
           "Returns the newly-created attributes"
           entity => {::address/id     real-id
-                     ::address/street "A St"})))
+                     ::address/street "A St"})
+        (component "id resolver"
+          (assertions
+            "Can return :db/id when requested"
+            (-> (parser {} [{[::address/id real-id] [:db/id]}])
+                first val :db/id) =fn=> int?))))
     (component "Saving a tree"
       (let [temp-person-id  (tempid/tempid)
             temp-address-id (tempid/tempid)

--- a/src/test/com/fulcrologic/rad/database_adapters/datomic_common_spec.clj
+++ b/src/test/com/fulcrologic/rad/database_adapters/datomic_common_spec.clj
@@ -26,7 +26,6 @@
 
 (use-fixtures :each with-env)
 
-; TODO -- move to common-spec
 (specification "native ID pull query transform" :focus
   (component "pathom-query->datomic-query"
     (let [incoming-query         [::person/id

--- a/src/test/com/fulcrologic/rad/test_schema/address.clj
+++ b/src/test/com/fulcrologic/rad/test_schema/address.clj
@@ -16,4 +16,9 @@
    ao/required?  true
    ao/schema     :production})
 
-(def attributes [id enabled? street])
+;; Make it possible to request the native :db/id from the db in addition to :address/id
+(defattr db-id :db/id :long
+  {ao/identities #{::id}
+   ao/schema     :production})
+
+(def attributes [id enabled? street db-id])


### PR DESCRIPTION
Issue: Including :db/id in the query for an entity that does not use native ids did not return it, because the branch of code for native ids was triggered.